### PR TITLE
Add Brewzilla styles and block-based table

### DIFF
--- a/assets/brewzilla.css
+++ b/assets/brewzilla.css
@@ -1,13 +1,44 @@
-:root {
-  --color-cta: #ff5400;
+@import url('https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@400;600&display=swap');
+
+:root{
+  /* colours */
+  --bz-purple:#5321A6;
+  --bz-green:#2AFF7F;
+  --bz-ink:#141414;
+  --bz-cream:#FFF7ED;
+
+  /* typography */
+  --font-headings:'Archivo Black', sans-serif;
+  --font-body:'Inter', sans-serif;
 }
 
-.card:hover {
-  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+body{font-family:var(--font-body);color:var(--bz-ink);background:var(--bz-cream);}
+h1,h2,h3,h4{font-family:var(--font-headings);}
+
+.announcement-bar{background:var(--bz-purple);color:#fff;height:40px;font-weight:600;display:flex;align-items:center;justify-content:center;}
+
+.btn{background:var(--bz-green);color:#000;padding:0.9rem 2.4rem;border-radius:9999px;font-weight:600;transition:transform .15s ease-in-out;}
+.btn:hover{transform:scale(1.05);}
+
+.hero-banner{background-size:cover;background-position:center;padding:8rem 1rem;text-align:center;color:#fff;}
+
+.product-marquee .card{box-shadow:0 6px 16px rgb(0 0 0 / .08);border-radius:12px;transition:transform .15s;}
+.product-marquee .card:hover{transform:translateY(-4px);}
+.product-marquee .price{font-weight:600;}
+
+.quick-add__submit{background:var(--bz-purple);color:#fff;border-radius:8px;font-weight:600;}
+.quick-add__submit:hover{background:#3e1781;}
+
+.usp-icons{display:flex;gap:2rem;justify-content:center;margin:4rem 0;}
+.usp-icons svg{width:56px;height:56px;margin-bottom:.5rem;fill:none;stroke:var(--bz-purple);stroke-width:2px;}
+
+.press-logos img{filter:grayscale(100%);opacity:.6;transition:opacity .2s;}
+.press-logos img:hover{opacity:1;}
+
+@media (prefers-reduced-motion:no-preference){
+  .fade-in{opacity:0;transform:translateY(20px);transition:all .4s ease-out;}
+  .fade-in.is-visible{opacity:1;transform:none;}
 }
 
-.press-logos img {
-  filter: grayscale(100%);
-}
-[data-fade]{opacity:0;transform:translateY(20px);transition:opacity .6s,transform .6s;}
-.fade-in{opacity:1;transform:none;}
+@media(min-width:768px){h1.hero-title{font-size:4.5rem;}}
+@media(min-width:1280px){h1.hero-title{font-size:6rem;}}

--- a/assets/fade-observer.js
+++ b/assets/fade-observer.js
@@ -1,12 +1,9 @@
-const els = document.querySelectorAll('[data-fade]');
-if (els.length) {
-  const io = new IntersectionObserver(entries => {
-    entries.forEach(e => {
-      if (e.isIntersecting) {
-        e.target.classList.add('fade-in');
-        io.unobserve(e.target);
-      }
-    });
-  }, { threshold: 0.1 });
-  els.forEach(el => io.observe(el));
-}
+const io = new IntersectionObserver((entries) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('is-visible');
+      io.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+document.querySelectorAll('.fade-in').forEach(el => io.observe(el));

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1463,5 +1463,16 @@
         "default": "Free shipping on orders over $50"
       }
     ]
+  },
+  {
+    "name": "Brewzilla colors",
+    "settings": [
+      {
+        "type": "color",
+        "id": "bz_purple",
+        "label": "Brewzilla purple",
+        "default": "#5321A6"
+      }
+    ]
   }
 ]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -257,6 +257,9 @@
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
     {{ 'brewzilla.css' | asset_url | stylesheet_tag }}
+    <style>
+      :root{ --bz-purple: {{ settings.bz_purple }}; }
+    </style>
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}

--- a/sections/comparison-table.liquid
+++ b/sections/comparison-table.liquid
@@ -6,19 +6,19 @@
   <table class="min-w-full text-left">
     <thead>
       <tr>
-        <th></th>
-        {% for column in section.blocks %}
-          <th>{{ column.settings.heading }}</th>
-        {% endfor %}
+        <th>Metric</th>
+        <th>Brewzilla</th>
+        <th>Big brand</th>
+        <th>Specialty</th>
       </tr>
     </thead>
     <tbody>
-      {% for row in section.settings.rows %}
-        <tr>
-          <th>{{ row.label }}</th>
-          {% for column in section.blocks %}
-            <td>{{ row[column.id] }}</td>
-          {% endfor %}
+      {% for block in section.blocks %}
+        <tr {{ block.shopify_attributes }}>
+          <td>{{ block.settings.metric }}</td>
+          <td>{{ block.settings.brewzilla }}</td>
+          <td>{{ block.settings.big_brand }}</td>
+          <td>{{ block.settings.specialty }}</td>
         </tr>
       {% endfor %}
     </tbody>
@@ -27,17 +27,19 @@
 
 {% schema %}
 {
-  "name": "Comparison Table",
-  "settings": [
-    {"id":"rows","type":"textarea","label":"JSON rows"}
-  ],
+  "name": "Comparison table",
   "blocks": [
     {
-      "type":"column",
-      "name":"Column",
-      "settings":[{"id":"heading","type":"text","label":"Heading"},{"id":"id","type":"text","label":"Key"}]
+      "type": "row",
+      "name": "Row",
+      "settings": [
+        { "type": "text", "id": "metric", "label": "Metric" },
+        { "type": "text", "id": "brewzilla", "label": "Brewzilla" },
+        { "type": "text", "id": "big_brand", "label": "Big brand" },
+        { "type": "text", "id": "specialty", "label": "Specialty" }
+      ]
     }
   ],
-  "presets":[{"name":"Comparison Table"}]
+  "presets": [{ "name": "Comparison table" }]
 }
 {% endschema %}

--- a/sections/hero-banner.liquid
+++ b/sections/hero-banner.liquid
@@ -4,7 +4,7 @@
 
 <section class="hero-banner relative bg-cover bg-center text-white"
         style="background-image:linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url({{ section.settings.bg | img_url: '2048x' }})">
-  <div class="hero-inner max-w-5xl mx-auto py-28 text-center" data-fade>
+  <div class="hero-inner max-w-5xl mx-auto py-28 text-center fade-in">
     <h1 class="text-5xl md:text-7xl font-bold mb-6">{{ section.settings.heading }}</h1>
     <p class="text-xl mb-8">{{ section.settings.subtext }}</p>
     <a href="{{ section.settings.cta_link }}" class="btn">{{ section.settings.cta_label }}</a>


### PR DESCRIPTION
## Summary
- add Brewzilla style sheet with brand colours, fonts and UI tweaks
- observe fade-in elements with a lighter JS observer
- update hero banner to use new fade classes
- make comparison table editable via Theme Editor blocks
- expose Brewzilla purple in settings and pipe it into CSS

## Testing
- `shopify theme check`

------
https://chatgpt.com/codex/tasks/task_e_6863de41fa58832db529d959c4ba64ca