### PR TITLE
Add three-column section under hero

### DIFF
--- a/sections/three-columns.liquid
+++ b/sections/three-columns.liquid
@@ -1,0 +1,51 @@
+{% comment %}
+  three-columns.liquid - header with three image+text columns
+{% endcomment %}
+
+<section class="three-columns page-width text-center">
+  {% if section.settings.heading != blank %}
+    <h2 class="text-3xl font-bold mb-8">{{ section.settings.heading }}</h2>
+  {% endif %}
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+    {% for block in section.blocks %}
+      <div {{ block.shopify_attributes }}>
+        {% if block.settings.image != blank %}
+          {{ block.settings.image | image_url: width: 600 | image_tag }}
+        {% endif %}
+        {% if block.settings.text != blank %}
+          <p class="mt-4">{{ block.settings.text }}</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Three Columns",
+  "max_blocks": 3,
+  "settings": [
+    { "id": "heading", "type": "text", "label": "Heading" }
+  ],
+  "blocks": [
+    {
+      "type": "column",
+      "name": "Column",
+      "settings": [
+        { "id": "image", "type": "image_picker", "label": "Image" },
+        { "id": "text", "type": "text", "label": "Text" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Three Columns",
+      "blocks": [
+        { "type": "column" },
+        { "type": "column" },
+        { "type": "column" }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.json
+++ b/templates/index.json
@@ -18,6 +18,18 @@
         "cta_link": ""
       }
     },
+    "three_columns": {
+      "type": "three-columns",
+      "settings": {
+        "heading": ""
+      },
+      "blocks": {
+        "col1": {"type": "column", "settings": {"image": "", "text": ""}},
+        "col2": {"type": "column", "settings": {"image": "", "text": ""}},
+        "col3": {"type": "column", "settings": {"image": "", "text": ""}}
+      },
+      "block_order": ["col1", "col2", "col3"]
+    },
     "marquee": {
       "type": "product-marquee",
       "settings": {
@@ -96,6 +108,7 @@
   },
   "order": [
     "hero",
+    "three_columns",
     "marquee",
     "usps",
     "feature",


### PR DESCRIPTION
## Summary
- create a `three-columns` section with editable heading, images and text
- register new section in `index.json` just below the hero

## Testing
- `python3 - <<'EOF'
import json,sys,re
content=open('templates/index.json').read()
print('valid' if json.loads(re.sub(r'/\*.*?\*/','',content)) else 'invalid')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6863fb275cf4832d980306c51587627c